### PR TITLE
fix: add .npmrc to fix Vercel deploy with Astro 6

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
Vercel's `npm install` fails because `@astrojs/tailwind@5.x` declares peer dep `astro@^3||^4||^5` but does not explicitly support `^6`.

Fix: add `.npmrc` with `legacy-peer-deps=true` so npm skips the peer dep check (same flag used locally).